### PR TITLE
han/hotfix/message-deletion

### DIFF
--- a/events/discordEvents/message/propChannelMessage.js
+++ b/events/discordEvents/message/propChannelMessage.js
@@ -40,7 +40,7 @@ module.exports = {
       const configExists = await PollChannel.configExists(channelId);
 
       // if (channelId !== propChannelId || botId === authorId) return;
-      if (!configExists || nermanIds.includes(botId)) {
+      if (!configExists || nermanIds.includes(authorId)) {
          // if (!configExists || botId === authorId) {
          Logger.info(
             'events/poll/propChannelMessage.js: Message was not invalid, so it was not deleted.',


### PR DESCRIPTION
The previous implementation would always return true since your bot id would always be a valid bot. Now it checks that the current author is a valid bot, which should return the desired output (deleting user messages but preventing bots from deleting each other's messages).