### PR TITLE
Feed Soft Delete

### DIFF
--- a/commands/slashCommands/feeds/add.js
+++ b/commands/slashCommands/feeds/add.js
@@ -41,6 +41,9 @@ module.exports = {
             guildId: interaction.guildId,
             channelId: channel.id,
             eventName: event,
+            isDeleted: {
+               $ne: true,
+            },
          });
       } catch (error) {
          Logger.error(

--- a/commands/slashCommands/feeds/remove.js
+++ b/commands/slashCommands/feeds/remove.js
@@ -41,6 +41,9 @@ module.exports = {
             guildId: interaction.guildId,
             channelId: channel.id,
             eventName: event,
+            isDeleted: {
+               $ne: true,
+            },
          }).exec();
       } catch (error) {
          Logger.error(

--- a/db/schemas/FeedConfig.js
+++ b/db/schemas/FeedConfig.js
@@ -17,17 +17,38 @@ const FeedConfigSchema = new Schema(
          enum: [...events.keys()],
          required: true,
       },
+      isDeleted: {
+         type: Boolean,
+         required: false,
+         default: false,
+      },
    },
    {
       statics: {
          async findChannels(eventName) {
-            return this.find({ eventName: eventName }).exec();
+            return this.find({
+               eventName: eventName,
+               isDeleted: {
+                  $ne: true,
+               },
+            }).exec();
          },
          async findFeedsInGuild(guildId) {
-            return this.find({ guildId: guildId }).exec();
+            return this.find({
+               guildId: guildId,
+               isDeleted: {
+                  $ne: true,
+               },
+            }).exec();
          },
          async findFeedsInChannel(guildId, channelId) {
-            return this.find({ guildId: guildId, channelId: channelId }).exec();
+            return this.find({
+               guildId: guildId,
+               channelId: channelId,
+               isDeleted: {
+                  $ne: true,
+               },
+            }).exec();
          },
       },
    },

--- a/events/discordEvents/client/ready.js
+++ b/events/discordEvents/client/ready.js
@@ -342,6 +342,32 @@ async function sendToChannelFeeds(eventName, data, client) {
                   channelId: feed.channelId,
                },
             );
+
+            // https://discord.com/developers/docs/topics/opcodes-and-status-codes
+            const UNKNOWN_CHANNEL_ERROR_CODE = 10003;
+            if (error.code === UNKNOWN_CHANNEL_ERROR_CODE) {
+               feed.isDeleted = true;
+               feed
+                  .save()
+                  .then(() => {
+                     Logger.debug(
+                        "events/discordEvents/client/ready.js: Soft-deleted the non-existant channel's feed config.",
+                        {
+                           channelId: feed.channelId,
+                           guildId: feed.guildId,
+                           feedEvent: feed.eventName,
+                        },
+                     );
+                  })
+                  .catch(err => {
+                     Logger.error(
+                        'events/discordEvents/client/ready.js: Unable to soft-delete the feed config.',
+                        {
+                           error: err,
+                        },
+                     );
+                  });
+            }
          }
       });
 }


### PR DESCRIPTION
Implemented a way to soft-delete unknown channels. There was a problem where deleted channels with feeds would throw errors. This is an attempt at fixing that issue by automatically soft-deleting those feed configs whose channels are missing.

A soft-delete was chosen so we could quickly revert things if something was deleted by mistake. It also gives us the option to manually prune through the database and permanently delete things we are confident of.