### PR TITLE
Added try to message retrieval for graceful fail..

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -202,12 +202,23 @@ module.exports = async client => {
                            },
                         );
 
-                        const message = await (client.channels.cache
-                           .get(closingPoll.config.channelId)
-                           .messages.cache.get(closingPoll.messageId) ??
-                           client.channels.cache
+                        let message = null;
+                        try {
+                           message = await (client.channels.cache
                               .get(closingPoll.config.channelId)
-                              .messages.fetch(closingPoll.messageId));
+                              .messages.cache.get(closingPoll.messageId) ??
+                              client.channels.cache
+                                 .get(closingPoll.config.channelId)
+                                 .messages.fetch(closingPoll.messageId));
+                        } catch (error) {
+                           Logger.error(
+                              'db/index.js: Error. Unable to find the message.',
+                              {
+                                 error: error,
+                              },
+                           );
+                           message = null;
+                        }
 
                         Logger.debug('db/index.js: Message.', {
                            message: message,


### PR DESCRIPTION
- The staging version continuously throws an error because it can't find a message.
- This wraps message retrieval in a try block, so we can safely remove the unfound poll from the queue and avoid being stuck on it.