### PR TITLE
Fixed prop status change title bug.

### DIFF
--- a/events/discordEvents/client/ready.js
+++ b/events/discordEvents/client/ready.js
@@ -288,7 +288,7 @@ module.exports = {
             });
 
             data.status = 'Canceled';
-            data.title = await fetchProposalTitle(data.id);
+            data.proposalTitle = await fetchProposalTitle(data.id);
             data.nounsForumType = 'PropStatusChange';
 
             sendToChannelFeeds('propStatusChange', data, client);
@@ -304,7 +304,7 @@ module.exports = {
             });
 
             data.status = 'Queued';
-            data.title = await fetchProposalTitle(data.id);
+            data.proposalTitle = await fetchProposalTitle(data.id);
             data.nounsForumType = 'PropStatusChange';
 
             sendToChannelFeeds('propStatusChange', data, client);
@@ -319,7 +319,7 @@ module.exports = {
             });
 
             data.status = 'Vetoed';
-            data.title = await fetchProposalTitle(data.id);
+            data.proposalTitle = await fetchProposalTitle(data.id);
             data.nounsForumType = 'PropStatusChange';
 
             sendToChannelFeeds('propStatusChange', data, client);
@@ -333,7 +333,7 @@ module.exports = {
             });
 
             data.status = 'Executed';
-            data.title = await fetchProposalTitle(data.id);
+            data.proposalTitle = await fetchProposalTitle(data.id);
             data.nounsForumType = 'PropStatusChange';
 
             sendToChannelFeeds('propStatusChange', data, client);

--- a/views/embeds/propStatusChange.js
+++ b/views/embeds/propStatusChange.js
@@ -3,11 +3,11 @@ const Poll = require('../../db/schemas/Poll');
 const Logger = require('../../helpers/logger');
 
 /**
- * @param {{id: string, status: string, title: string}} data
+ * @param {{id: string, status: string, proposalTitle: string}} data
  * @param {string} url
  */
 exports.generatePropStatusChangeEmbed = function (data, url) {
-   const title = data.title || `Proposal ${data.id}`;
+   const title = data.proposalTitle || `Proposal ${data.id}`;
    const description = `${url}${data.id}\n${data.status}`;
 
    const proposalEmbed = new MessageEmbed()


### PR DESCRIPTION
Forum posts created via prop status change events did not have the
correct title. The problem was due to these events using `title` instead
 of `proposalTitle` to store the title information.