### PR TITLE
Removed notification embed.

### DIFF
--- a/events/customEvents/nouns/transferNoun.js
+++ b/events/customEvents/nouns/transferNoun.js
@@ -15,15 +15,11 @@ module.exports = {
     *    tokenId: string}} data
     */
    async execute(channel, data) {
-      const noticeEmbed = generateTransferNounEmbed(data, false);
-      const messageEmbed = generateTransferNounEmbed(data, true);
+      const embed = generateTransferNounEmbed(data);
 
       try {
-         const message = await channel.send({
-            embeds: [noticeEmbed],
-         });
-         await message.edit({
-            embeds: [messageEmbed],
+         await channel.send({
+            embeds: [embed],
          });
       } catch (error) {
          return Logger.error('events/nouns/transferNoun.js: Received error.', {


### PR DESCRIPTION
Some embeds were missing links. I believe the reason is many
simultaneous transfers with notification embeds weren't correctly
updated with markdown. By removing the notification embed and going
directly for markdown embeds, everything should be rendered correctly
the first time.