### PR TITLE
database-and-poll-export-fixes

### DIFF
--- a/commands/context/exportPollReasons.js
+++ b/commands/context/exportPollReasons.js
@@ -42,15 +42,30 @@ const fetchPoll = async interaction => {
    return targetPoll;
 };
 
+/**
+ * @param {import('discord.js').Interaction} interaction
+ */
 const attachUsernames = async (interaction, targetPoll) => {
    for (let i = 0; i < targetPoll.getVotes.length; ++i) {
       if (targetPoll.config.anonymous) {
          targetPoll.getVotes[i].username = 'anonymous';
       } else {
-         const guildUser = await interaction.guild.members.fetch(
-            targetPoll.getVotes[i].user,
-         );
-         targetPoll.getVotes[i].username = guildUser.user.username;
+         try {
+            const guildUser = await interaction.guild.members.fetch(
+               targetPoll.getVotes[i].user,
+            );
+            targetPoll.getVotes[i].username = guildUser.user.username;
+         } catch (error) {
+            Logger.warn(
+               'commands/context/exportPollReasons.js: Unable to retrieve guild user.',
+               {
+                  userId: targetPoll.getVotes[i].user,
+                  guildId: interaction.guildId,
+                  error: error,
+               },
+            );
+            targetPoll.getVotes[i].username = targetPoll.getVotes[i].user;
+         }
       }
    }
 };

--- a/db/index.js
+++ b/db/index.js
@@ -24,8 +24,6 @@ module.exports = async client => {
 
    // create empty options object
    const options = {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
       heartbeatFrequencyMS: 10000,
    };
 

--- a/db/index.js
+++ b/db/index.js
@@ -33,8 +33,6 @@ module.exports = async client => {
       process.env.DEPLOY_STAGE === 'staging'
    ) {
       options.autoIndex = false;
-      options.keepAlive = true; // this is true by default since v5.2.0 but keeping it as a reminder
-      options.keepAliveInitialDelay = 300000;
    }
    Logger.info('db/index.js: Checking options.', {
       options: options,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
             "graphql": "^16.5.0",
             "graphql-request": "^4.3.0",
             "mongodb": "^4.2.2",
-            "mongoose": "^6.2.7",
+            "mongoose": "^8.1.1",
             "nerman": "^0.0.34",
             "node-fetch": "^2.6.6",
             "twit": "^2.2.11"
@@ -1797,7 +1797,6 @@
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.1.tgz",
          "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
-         "optional": true,
          "dependencies": {
             "sparse-bitfield": "^3.0.3"
          }
@@ -1904,17 +1903,17 @@
          }
       },
       "node_modules/@prophouse/protocol": {
-         "version": "1.0.4",
-         "resolved": "https://registry.npmjs.org/@prophouse/protocol/-/protocol-1.0.4.tgz",
-         "integrity": "sha512-+BhLmr+8HRJ27JzdBpjfcLFjQwyK1hWFFJG9eSmE7HBzg+rWq+0VWgfzzDUqKrcy9FOegXgb6yWzo2mTSWPXYw==",
+         "version": "1.0.8",
+         "resolved": "https://registry.npmjs.org/@prophouse/protocol/-/protocol-1.0.8.tgz",
+         "integrity": "sha512-XSYA5iqrbD2pyZFD3bSoJKFOeQs/9LgElddZ1cOj6UzQhe2xA0e5ZW5aTwGqEW4eIq8Ed6Am8ruNF8SwyAcphA==",
          "dependencies": {
             "ethers": "~5.7.2"
          }
       },
       "node_modules/@prophouse/sdk": {
-         "version": "1.0.15",
-         "resolved": "https://registry.npmjs.org/@prophouse/sdk/-/sdk-1.0.15.tgz",
-         "integrity": "sha512-pibjY2rpOXzHB3ZV6DCLK9vGwh3kM6T4L/pcs7pAoc5qw+N/7F3Ou30grZoEVpBWLkve+bCSHgGN5KZCmcPKYg==",
+         "version": "1.0.27",
+         "resolved": "https://registry.npmjs.org/@prophouse/sdk/-/sdk-1.0.27.tgz",
+         "integrity": "sha512-lQoa0S3fqty4ccYJ0EJoklRU3812SB3dSmR4xmw/qExCndkuqswndHzt/dZLHQwdZFJy8oHUZ1ac3TKB2SRgiw==",
          "dependencies": {
             "@ethersproject/abi": "~5.7.0",
             "@ethersproject/abstract-provider": "~5.7.0",
@@ -1930,7 +1929,7 @@
             "@ethersproject/strings": "~5.7.0",
             "@ethersproject/wallet": "^5.7.0",
             "@pinata/sdk": "^2.1.0",
-            "@prophouse/protocol": "1.0.4",
+            "@prophouse/protocol": "1.0.8",
             "bn.js": "^5.2.1",
             "ethereumjs-fork-block": "^4.2.4",
             "ethereumjs-fork-common": "^3.1.3",
@@ -4039,9 +4038,9 @@
          "dev": true
       },
       "node_modules/follow-redirects": {
-         "version": "1.15.3",
-         "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-         "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+         "version": "1.15.5",
+         "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+         "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
          "funding": [
             {
                "type": "individual",
@@ -4738,8 +4737,7 @@
       "node_modules/memory-pager": {
          "version": "1.5.0",
          "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-         "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-         "optional": true
+         "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
       },
       "node_modules/merkletreejs": {
          "version": "0.3.11",
@@ -4922,47 +4920,123 @@
          }
       },
       "node_modules/mongoose": {
-         "version": "6.12.3",
-         "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.12.3.tgz",
-         "integrity": "sha512-MNJymaaXali7w7rHBxVUoQ3HzHHMk/7I/+yeeoSa4rUzdjZwIWQznBNvVgc0A8ghuJwsuIkb5LyLV6gSjGjWyQ==",
+         "version": "8.1.1",
+         "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.1.1.tgz",
+         "integrity": "sha512-DbLb0NsiEXmaqLOpEz+AtAsgwhRw6f25gwa1dF5R7jj6lS1D8X6uTdhBSC8GDVtOwe5Tfw2EL7nTn6hiJT3Bgg==",
          "dependencies": {
-            "bson": "^4.7.2",
+            "bson": "^6.2.0",
             "kareem": "2.5.1",
-            "mongodb": "4.17.1",
+            "mongodb": "6.3.0",
             "mpath": "0.9.0",
-            "mquery": "4.0.3",
+            "mquery": "5.0.0",
             "ms": "2.1.3",
             "sift": "16.0.1"
          },
          "engines": {
-            "node": ">=12.0.0"
+            "node": ">=16.20.1"
          },
          "funding": {
             "type": "opencollective",
             "url": "https://opencollective.com/mongoose"
          }
       },
-      "node_modules/mongoose/node_modules/mongodb": {
-         "version": "4.17.1",
-         "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.1.tgz",
-         "integrity": "sha512-MBuyYiPUPRTqfH2dV0ya4dcr2E5N52ocBuZ8Sgg/M030nGF78v855B3Z27mZJnp8PxjnUquEnAtjOsphgMZOlQ==",
+      "node_modules/mongoose/node_modules/@types/whatwg-url": {
+         "version": "11.0.4",
+         "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.4.tgz",
+         "integrity": "sha512-lXCmTWSHJvf0TRSO58nm978b8HJ/EdsSsEKLd3ODHFjo+3VGAyyTp4v50nWvwtzBxSMQrVOK7tcuN0zGPLICMw==",
          "dependencies": {
-            "bson": "^4.7.2",
-            "mongodb-connection-string-url": "^2.6.0",
-            "socks": "^2.7.1"
+            "@types/webidl-conversions": "*"
+         }
+      },
+      "node_modules/mongoose/node_modules/bson": {
+         "version": "6.2.0",
+         "resolved": "https://registry.npmjs.org/bson/-/bson-6.2.0.tgz",
+         "integrity": "sha512-ID1cI+7bazPDyL9wYy9GaQ8gEEohWvcUl/Yf0dIdutJxnmInEEyCsb4awy/OiBfall7zBA179Pahi3vCdFze3Q==",
+         "engines": {
+            "node": ">=16.20.1"
+         }
+      },
+      "node_modules/mongoose/node_modules/mongodb": {
+         "version": "6.3.0",
+         "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.3.0.tgz",
+         "integrity": "sha512-tt0KuGjGtLUhLoU263+xvQmPHEGTw5LbcNC73EoFRYgSHwZt5tsoJC110hDyO1kjQzpgNrpdcSza9PknWN4LrA==",
+         "dependencies": {
+            "@mongodb-js/saslprep": "^1.1.0",
+            "bson": "^6.2.0",
+            "mongodb-connection-string-url": "^3.0.0"
          },
          "engines": {
-            "node": ">=12.9.0"
+            "node": ">=16.20.1"
          },
-         "optionalDependencies": {
-            "@aws-sdk/credential-providers": "^3.186.0",
-            "@mongodb-js/saslprep": "^1.1.0"
+         "peerDependencies": {
+            "@aws-sdk/credential-providers": "^3.188.0",
+            "@mongodb-js/zstd": "^1.1.0",
+            "gcp-metadata": "^5.2.0",
+            "kerberos": "^2.0.1",
+            "mongodb-client-encryption": ">=6.0.0 <7",
+            "snappy": "^7.2.2",
+            "socks": "^2.7.1"
+         },
+         "peerDependenciesMeta": {
+            "@aws-sdk/credential-providers": {
+               "optional": true
+            },
+            "@mongodb-js/zstd": {
+               "optional": true
+            },
+            "gcp-metadata": {
+               "optional": true
+            },
+            "kerberos": {
+               "optional": true
+            },
+            "mongodb-client-encryption": {
+               "optional": true
+            },
+            "snappy": {
+               "optional": true
+            },
+            "socks": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/mongoose/node_modules/mongodb-connection-string-url": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.0.tgz",
+         "integrity": "sha512-t1Vf+m1I5hC2M5RJx/7AtxgABy1cZmIPQRMXw+gEIPn/cZNF3Oiy+l0UIypUwVB5trcWHq3crg2g3uAR9aAwsQ==",
+         "dependencies": {
+            "@types/whatwg-url": "^11.0.2",
+            "whatwg-url": "^13.0.0"
          }
       },
       "node_modules/mongoose/node_modules/ms": {
          "version": "2.1.3",
          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      },
+      "node_modules/mongoose/node_modules/tr46": {
+         "version": "4.1.1",
+         "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+         "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+         "dependencies": {
+            "punycode": "^2.3.0"
+         },
+         "engines": {
+            "node": ">=14"
+         }
+      },
+      "node_modules/mongoose/node_modules/whatwg-url": {
+         "version": "13.0.0",
+         "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+         "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+         "dependencies": {
+            "tr46": "^4.1.1",
+            "webidl-conversions": "^7.0.0"
+         },
+         "engines": {
+            "node": ">=16"
+         }
       },
       "node_modules/mpath": {
          "version": "0.9.0",
@@ -4973,14 +5047,14 @@
          }
       },
       "node_modules/mquery": {
-         "version": "4.0.3",
-         "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
-         "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+         "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
          "dependencies": {
             "debug": "4.x"
          },
          "engines": {
-            "node": ">=12.0.0"
+            "node": ">=14.0.0"
          }
       },
       "node_modules/ms": {
@@ -5873,7 +5947,6 @@
          "version": "3.0.3",
          "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
          "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-         "optional": true,
          "dependencies": {
             "memory-pager": "^1.0.2"
          }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       "graphql": "^16.5.0",
       "graphql-request": "^4.3.0",
       "mongodb": "^4.2.2",
-      "mongoose": "^6.2.7",
+      "mongoose": "^8.1.1",
       "nerman": "^0.0.34",
       "node-fetch": "^2.6.6",
       "twit": "^2.2.11"


### PR DESCRIPTION
- Updated Mongoose to a newer version to support MongoDB v7.
- Added try-catch when retrieving usernames in poll-exports to avoid a failure when the user leaves the guild.