### PR TITLE
feat: set read preference to 'primaryPreferred'

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -25,6 +25,7 @@ module.exports = async client => {
    // create empty options object
    const options = {
       heartbeatFrequencyMS: 10000,
+      readPreference: 'primaryPreferred',
    };
 
    // Turn off auto indexing in production, because it's expensive on performance


### PR DESCRIPTION
The production db occasionally fails with a connection time out error, resulting in a crash and further time outs. This is an attempt at alleviating the problem by connecting to secondary shard.